### PR TITLE
YtdlpResolverの修正

### DIFF
--- a/Editor/Playlist/YtdlpResolver.cs
+++ b/Editor/Playlist/YtdlpResolver.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 using Debug = UnityEngine.Debug;
 
@@ -17,11 +18,14 @@ namespace Yamadev.YamaStream.Editor
         private const string FILENAME = "yt-dlp.exe";
 #elif UNITY_EDITOR_OSX
         private const string FILENAME = "yt-dlp_macos";
-        private const uint EXECUTABLE_PERMISSION = 0x100 | 0x40 | 0x80 | 0x20 | 0x8 | 0x4 | 0x1; // 0755
 #elif UNITY_EDITOR_LINUX
         private const string FILENAME = "yt-dlp_linux";
 #else
         private const string FILENAME = "yt-dlp";
+#endif
+
+#if UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
+        private const uint EXECUTABLE_PERMISSION = 0x100 | 0x40 | 0x80 | 0x20 | 0x8 | 0x4 | 0x1; // 0755
 #endif
 
         private static readonly string DownloadUrl = $"https://github.com/yt-dlp/yt-dlp/releases/latest/download/{FILENAME}";


### PR DESCRIPTION
`Editor/Playlist/YtdlpResolver.cs`において、

- Linux側でも使用しているにも関わらずmacOS側でのみ`EXECUTABLE_PERMISSION`が定義されていた問題
- `DllImport`が定義されている`System.Runtime.InteropServices`名前空間がusingされていない問題

を修正しました。