### PR TITLE
Update VideoPlayerResolver.cs

### DIFF
--- a/Editor/Common/VideoPlayerResolver.cs
+++ b/Editor/Common/VideoPlayerResolver.cs
@@ -65,7 +65,7 @@ namespace Yamadev.YamaStream.Editor
             MediaPlayer mediaPlayer = avPro.gameObject.AddComponent<MediaPlayer>();
 #if UNITY_EDITOR_WIN
             OptionsWindows options = (OptionsWindows)mediaPlayer.GetCurrentPlatformOptions();
-            options._audioMode = Windows.AudioOutput.Unity;
+            options.audioOutput = Windows.AudioOutput.Unity;
 #endif
             VRCAVProVideoScreen[] vrcAVProVideoScreens = Utils.FindComponentsInHierarthy<VRCAVProVideoScreen>();
             foreach (VRCAVProVideoScreen screen in vrcAVProVideoScreens)


### PR DESCRIPTION
Fix for the following error seen in 1.6.0-beta.6

Packages\net.kwxxw.yama-stream\Editor\Common\VideoPlayerResolver.cs(68,21): error CS1061: 'MediaPlayer.OptionsWindows' does not contain a definition for '_audioMode' and no accessible extension method '_audioMode' accepting a first argument of type 'MediaPlayer.OptionsWindows' could be found (are you missing a using directive or an assembly reference?)