### PR TITLE
feat: set global screen texture variable

### DIFF
--- a/Assets/translation_editor.json
+++ b/Assets/translation_editor.json
@@ -152,7 +152,8 @@
     "color": "カラー",
     "useLightVolumes": "Light Volumeを使用",
     "playerSettings": "動画プレイヤー設定",
-    "targetLightVolumes": "対象のLight Volume"
+    "targetLightVolumes": "対象のLight Volume",
+    "useGlobalTexture": "グローバルビデオテクスチャを使用する"
   },
   "en-US": {
     "ui": "UI",
@@ -307,7 +308,8 @@
     "color": "Color",
     "useLightVolumes": "Use Light Volume",
     "playerSettings": "Player Settings",
-    "targetLightVolumes": "Target Light Volumes"
+    "targetLightVolumes": "Target Light Volumes",
+    "useGlobalTexture": "Use global video texture"
   },
   "zh-CN": {
     "ui": "UI",
@@ -462,7 +464,8 @@
     "color": "颜色",
     "useLightVolumes": "使用Light Volume",
     "playerSettings": "播放器设置",
-    "targetLightVolumes": "目標Light Volume"
+    "targetLightVolumes": "目標Light Volume",
+    "useGlobalTexture": "使用全局视频纹理"
   },
   "zh-TW": {
     "ui": "UI",
@@ -617,7 +620,8 @@
     "color": "顏色",
     "useLightVolumes": "使用Light Volume",
     "playerSettings": "播放器設定",
-    "targetLightVolumes": "目標Light Volume"
+    "targetLightVolumes": "目標Light Volume",
+    "useGlobalTexture": "使用全域影片紋理"
   },
   "ko-KR": {
     "ui": "UI",
@@ -772,7 +776,8 @@
     "color": "색상",
     "useLightVolumes": "Light Volume 사용",
     "playerSettings": "플레이어 설정",
-    "targetLightVolumes": "대상 Light Volume"
+    "targetLightVolumes": "대상 Light Volume",
+    "useGlobalTexture": "글로벌 비디오 텍스쳐 사용"
   },
   "es-CL": {
     "ui": "Interfaz",
@@ -927,6 +932,7 @@
     "color": "Color",
     "useLightVolumes": "Usar Light Volume",
     "playerSettings": "Configuración del Reproductor",
-    "targetLightVolumes": "Volúmenes de Luz Objetivo"
+    "targetLightVolumes": "Volúmenes de Luz Objetivo",
+    "useGlobalTexture": "Usar textura de video global"
   }
 }

--- a/Editor/Inspector/ExternalSettings.cs
+++ b/Editor/Inspector/ExternalSettings.cs
@@ -23,6 +23,7 @@ namespace Yamadev.YamaStream.Editor
         private readonly SerializedProperty _useLTCGI;
         private readonly SerializedProperty _useLightVolumes;
         private readonly SerializedProperty _targetLightVolumes;
+        private readonly SerializedProperty _useGlobalTexture;
 
         public bool IsValid => _controller != null && _controllerSerializedObject != null;
 
@@ -45,6 +46,7 @@ namespace Yamadev.YamaStream.Editor
 
                 _useAudioLink = _controllerSerializedObject.FindProperty("_useAudioLink");
                 _audioLink = _controllerSerializedObject.FindProperty("_audioLink");
+                _useGlobalTexture = _controllerSerializedObject.FindProperty("_useGlobalTexture");
             }
         }
 
@@ -166,6 +168,11 @@ namespace Yamadev.YamaStream.Editor
 #else
             EditorGUILayout.LabelField("Light Volumes", Localization.Get("vrclvNotImported"));
 #endif
+        }
+        
+        public void DrawGlobalTextureSettings()
+        {
+            EditorGUILayout.PropertyField(_useGlobalTexture, Localization.GetLayout("useGlobalTexture"));
         }
 
         public void ApplyModifiedProperties()

--- a/Editor/Inspector/YamaPlayerEditor.cs
+++ b/Editor/Inspector/YamaPlayerEditor.cs
@@ -222,6 +222,7 @@ namespace Yamadev.YamaStream.Editor
                 _externalSettings.DrawAudioLinkSettings();
                 _externalSettings.DrawLTCGISettings();
                 _externalSettings.DrawLVTVGISettings();
+                _externalSettings.DrawGlobalTextureSettings();
             }
 
             using (new SectionScope(Localization.Get("screenSettings"), false))

--- a/Runtime/Internal/Controller_Screen.cs
+++ b/Runtime/Internal/Controller_Screen.cs
@@ -10,11 +10,14 @@ namespace Yamadev.YamaStream
     {
         [SerializeField] private int _maxResolution;
         [SerializeField] private bool _mirrorFlip = true;
+        [SerializeField] private bool _useGlobalTexture = true;
         [SerializeField, Range(0f, 1f)] private float _emission = 1f;
         [SerializeField] private ScreenType[] _screenTypes;
         [SerializeField] private Object[] _screens;
         [SerializeField] private string[] _textureProperties;
         private MaterialPropertyBlock _propertyBlock;
+        private string _globalTextureName = "_Udon_VideoTex";
+        private int _globalTextureId;
 
         private void InitializePropertyBlock()
         {
@@ -30,6 +33,9 @@ namespace Yamadev.YamaStream
 
             _propertyBlock.SetInt("_MirrorFlip", _mirrorFlip ? 1 : 0);
             _propertyBlock.SetFloat("_Emission", _emission);
+            
+            if (_useGlobalTexture)
+                _globalTextureId = VRCShader.PropertyToID(globalTextureName);
         }
 
         public Texture Texture => Handler.Texture;
@@ -73,6 +79,9 @@ namespace Yamadev.YamaStream
 
         public override void OnTextureUpdated(Texture texture)
         {
+            if (_useGlobalTexture)
+                VRCShader.SetGlobalTexture(_globalTextureId, Texture);
+            
             InitializePropertyBlock();
 
             for (int i = 0; i < _screens.Length; i++)


### PR DESCRIPTION
Poiyomi (and some other shaders) consume a global Udon texture named `_Udon_VideoTex`. It seems to be mostly used for Poiyomi's [Video Texture](https://www.poiyomi.com/color-and-normals/decals#video-texture) feature, to create portable screens on avatars. Currently, ProTV seems to be the only player that supports this. This PR adds support for this global texture. This does _not_ add support for the `_Udon_VideoData` global.

The text translations were done by machine, except for English and Korean. Let me know about any corrections that need to be made.

(Also, thank you for making this player, it's my personal favorite!)