### PR TITLE
Fix TimeSpan.FromSeconds overflow crash during livestream playback

### DIFF
--- a/Runtime/Internal/Controller.cs
+++ b/Runtime/Internal/Controller.cs
@@ -76,11 +76,11 @@ namespace Yamadev.YamaStream
     public bool IsPlaying => Handler.IsPlaying;
     public bool IsError => Handler.IsError;
     public float Duration => Handler.Duration;
-    public string FormatedDuration => TimeSpan.FromSeconds(Duration).ToString(_timeFormat);
+    public string FormatedDuration => float.IsInfinity(Duration) || float.IsNaN(Duration) ? "" : TimeSpan.FromSeconds(Duration).ToString(_timeFormat);
     public float VideoTime => Handler.Time;
-    public string FormatedVideoTime => TimeSpan.FromSeconds(VideoTime).ToString(_timeFormat);
+    public string FormatedVideoTime => float.IsInfinity(VideoTime) || float.IsNaN(VideoTime) ? "" : TimeSpan.FromSeconds(VideoTime).ToString(_timeFormat);
     public bool IsLoading => Handler.IsLoading;
-    public bool IsLive => float.IsInfinity(Duration);
+    public bool IsLive => float.IsInfinity(Duration) || float.IsNaN(Duration);
 
     public YamaPlayerListener[] EventListeners
     {

--- a/Runtime/Internal/UI/UIController.cs
+++ b/Runtime/Internal/UI/UIController.cs
@@ -766,7 +766,8 @@ namespace Yamadev.YamaStream.UI
 
         if (showTooltip)
         {
-          var tooltipText = _controller.IsLive ? "Live" : TimeSpan.FromSeconds(_controller.Duration * _progressSliderHelper.Percent).ToString(_controller.TimeFormat);
+          var seekSeconds = _controller.Duration * _progressSliderHelper.Percent;
+          var tooltipText = _controller.IsLive || float.IsInfinity(seekSeconds) || float.IsNaN(seekSeconds) ? "Live" : TimeSpan.FromSeconds(seekSeconds).ToString(_controller.TimeFormat);
           _progressTooltipText.text = tooltipText;
         }
       }


### PR DESCRIPTION
## Bug Fix: `System.OverflowException` in `TimeSpan.FromSeconds()` during livestream playback

### Problem

After extended livestream playback (~2+ hours), the UdonBehaviour crashes with a `System.OverflowException` in `TimeSpan.FromSeconds()`. Once crashed, VRChat permanently halts the UdonBehaviour and the video player cannot recover without rejoining the world.

**Root cause:** AVPro reports `Infinity` or `NaN` for livestream duration (since live streams have no defined end time). These non-finite values are passed directly to `TimeSpan.FromSeconds()`, which throws `OverflowException` for `NaN`, `Infinity`, or excessively large values.

### Stack trace from VRChat log

```
[UdonBehaviour] An exception occurred during Udon execution, this UdonBehaviour will be halted.
VRC.Udon.VM.UdonVMException: An exception occurred during EXTERN to
     'SystemTimeSpan.__FromSeconds__SystemDouble__SystemTimeSpan'.
---> System.OverflowException: TimeSpan overflowed because the duration is too long.
  at UdonBehaviour.ManagedUpdate()
```

### Changes

1. **`Controller.FormatedDuration`** — Returns `\"\"` instead of crashing when `Duration` is `Infinity` or `NaN`
2. **`Controller.FormatedVideoTime`** — Returns `\"\"` instead of crashing when `VideoTime` is `Infinity` or `NaN`
3. **`Controller.IsLive`** — Now also returns `true` when `Duration` is `NaN` (previously only checked `Infinity`). This makes all downstream `IsLive` guards also protect against `NaN` duration.
4. **`UIController` progress tooltip** — Added guard against non-finite computed seek seconds

### Reproduction context

- Stream URL: MPEG-TS livestream via AVPro (MediaFoundation)
- Playback duration before crash: ~2 hours 24 minutes
- The crash occurs silently during normal playback — no video error precedes it"